### PR TITLE
PGPT-113: Add timestamp to the Icon URL to create a unique query parameter to bypass caching

### DIFF
--- a/apps/chat/src/components/Chatbar/ModelIcon.tsx
+++ b/apps/chat/src/components/Chatbar/ModelIcon.tsx
@@ -36,11 +36,17 @@ const ModelIconTemplate = memo(
     isInvalid,
     boxSize = MODEL_ICON_SIZE_DEFAULT.small,
   }: Omit<Props, 'isCustomTooltip'>) => {
+    const timeStamp = Date.now();
+
     const fallbackUrl =
       entity?.type === EntityType.Addon
-        ? 'api/themes/image?name=default-addon'
-        : 'api/themes/image?name=default-model';
+        ? `api/themes/image?name=default-addon&ts=${timeStamp}`
+        : `api/themes/image?name=default-model&ts=${timeStamp}`;
     const description = entity ? getOpenAIEntityFullName(entity) : entityId;
+
+    const iconUrlWithCacheBuster = entity?.iconUrl
+      ? `${entity.iconUrl}?ts=${timeStamp}`
+      : '';
 
     return (
       <span
@@ -53,7 +59,7 @@ const ModelIconTemplate = memo(
       >
         <SVG
           key={entityId}
-          src={entity?.iconUrl ? `${entity.iconUrl}?v2` : ''}
+          src={iconUrlWithCacheBuster}
           className={classNames(!entity?.iconUrl && 'hidden')}
           width={size}
           height="auto"

--- a/apps/chat/src/components/Chatbar/ModelIcon.tsx
+++ b/apps/chat/src/components/Chatbar/ModelIcon.tsx
@@ -36,6 +36,7 @@ const ModelIconTemplate = memo(
     isInvalid,
     boxSize = MODEL_ICON_SIZE_DEFAULT.small,
   }: Omit<Props, 'isCustomTooltip'>) => {
+    // PGPT-113: Using a timestamp as unique query param in Icon URL to bypass caching
     const timeStamp = Date.now();
 
     const fallbackUrl =


### PR DESCRIPTION
PGPT-113: Add timestamp to the Icon URL to create a unique query parameter to bypass caching