### PR TITLE
Fix announcement message background color

### DIFF
--- a/apps/chat/src/components/Common/AnnouncementBanner.tsx
+++ b/apps/chat/src/components/Common/AnnouncementBanner.tsx
@@ -21,7 +21,7 @@ export const AnnouncementsBanner = () => {
 
   return (
     <div
-      className="relative flex items-center justify-center bg-gradient-to-r from-accent-secondary to-accent-tertiary text-controls-permanent"
+      className="from-layer-8 to-layer-9 relative flex items-center justify-center bg-gradient-to-r text-pr-primary-700"
       data-qa="banner"
     >
       <div className="flex grow items-center justify-center gap-2 py-2 pl-2 pr-8 text-center md:gap-3 md:px-14">
@@ -29,7 +29,7 @@ export const AnnouncementsBanner = () => {
         <span dangerouslySetInnerHTML={{ __html: announcement }}></span>
       </div>
       <button
-        className="absolute right-2 top-[calc(50%_-_12px)] shrink-0"
+        className="absolute right-2 top-[calc(50%_-_12px)] shrink-0 text-quaternary-bg-light hover:text-primary-bg-light"
         onClick={() => {
           dispatch(UIActions.closeAnnouncement({ announcement }));
         }}

--- a/apps/chat/tailwind.config.js
+++ b/apps/chat/tailwind.config.js
@@ -9,6 +9,8 @@ const commonBgColors = {
   'layer-5': 'var(--bg-layer-5, #7FA5D0)',
   'layer-6': 'var(--bg-layer-6, #184487)',
   'layer-7': 'var(--bg-layer-7, #ECEEF4)',
+  'layer-8': 'var(--bg-layer-8, #C0DDF2)',
+  'layer-9': 'var(--bg-layer-9, #F3E8CE)',
   blackout: 'var(--bg-blackout, #090F2599)',
   'blackout-1': 'var(--bg-blackout-1, #1844870D)',
   'blackout-2': 'var(--bg-blackout-2, #023465CC)',


### PR DESCRIPTION
I used the same gradient as for tour guide.
![image](https://github.com/pernod-ricard-coe-data/PR.Data.GPT.ai-dial-chat/assets/167853645/ae5d7930-4616-4629-89ed-36602cdb240e)